### PR TITLE
Test with tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 before_install:
   - sudo apt-get install -y npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ python:
   - "3.6"
 
 before_install:
-  - sudo apt-get install -y librsvg2-bin npm
+  - sudo apt-get install -y npm
 
 install:
-  - pip install .[test]
+  - pip install tox-travis
 
 script:
-  - pytest -v
-
-
+  - tox

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7"
     ],
 
     # This field adds keywords for your project which will appear on the

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
         "test": [
             "xmldiff",
             #Per release notes, Python 2 support dropped at version 2.0.0
-            "cairosvg==1.0.22" if sys.version_info < (3, ) else "cairosvg",
+            "cairosvg<2" if sys.version_info.major < 3 else "cairosvg",
             "pillow"
         ],
     },

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -45,7 +45,7 @@ def test_upstream(tmpdir,wavedromdir,file):
     f_out = "{}/{}.svg".format(tmpdir, base)
     f_out_py = "{}/{}_py.svg".format(tmpdir, base)
 
-    subprocess.check_call("{}/bin/cli.js -i {} > {}".format(wavedromdir, file, f_out), shell=True)
+    subprocess.check_call("node {}/bin/cli.js -i {} > {}".format(wavedromdir, file, f_out), shell=True)
     wavedrom.render_file(file, f_out_py, strict_js_features=True)
 
     unknown = diff(f_out, f_out_py)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py35, py36
+
+[testenv]
+deps = pytest
+extras = test
+
+commands =
+    pytest -v {posargs}


### PR DESCRIPTION
I propose we use [tox](https://tox.readthedocs.io/en/latest/) to create the venvs and run pytest.  This should make it easier to test on more OSes and other CIs.

To use tox, make sure git, node, and npm are available.  `pip install tox` then just `tox` from the source directory (the same place you would run `pytest`).  It should also work if you are already inside a venv.  tox will only only tests on Python interpreters it can find, so typically any installed system-wide or in whatever virtual environment it is run from.