### PR TITLE
Test using tox conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 before_install:
   - sudo apt-get install -y npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,35 @@
+# Applied from https://github.com/conda/conda/blob/master/docs/source/user-guide/tasks/use-conda-with-travis-ci.rst
+
 language: python
 python:
+  # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
 
-before_install:
-  - sudo apt-get install -y npm
-
 install:
+  - sudo apt-get update
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
+    else
+      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+    fi
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - source "$HOME/miniconda/etc/profile.d/conda.sh"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
+
+  # Replace dep1 dep2 ... with your dependencies
+  # wavedrompy will use tox-conda, so all dependencies will be handled in tox.ini
+  - conda create -q -c conda-forge -n test-environment python=$TRAVIS_PYTHON_VERSION tox-conda
+  - conda activate test-environment
+
   - pip install tox-travis
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,10 @@ python:
   - "3.6"
 
 before_install:
-  - sudo apt-get install -y librsvg2-bin npm
+  - sudo apt-get install -y npm
 
 install:
-  - pip install .[test]
+  - pip install tox-travis
 
 script:
-  - pytest -v
-
-
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 # Applied from https://github.com/conda/conda/blob/master/docs/source/user-guide/tasks/use-conda-with-travis-ci.rst
 
 language: python
+
+# We don't actually use the Travis Python, but this keeps it organized.
+# But tox runs in Travis Python, so it has to be compatible with tox and its plugins.
+matrix:
+  include:
+  - name: "Python: 2.7"
+    python: 3.7
+    env: TOXENV=py27
 python:
-  # We don't actually use the Travis Python, but this keeps it organized.
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
@@ -12,11 +18,7 @@ install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-      wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
-    else
-      wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    fi
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - source "$HOME/miniconda/etc/profile.d/conda.sh"
   - hash -r

--- a/setup.py
+++ b/setup.py
@@ -107,6 +107,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7"
     ],
 
     # This field adds keywords for your project which will appear on the

--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ setup(
         "test": [
             "xmldiff",
             #Per release notes, Python 2 support dropped at version 2.0.0
-            "cairosvg==1.0.22" if sys.version_info < (3, ) else "cairosvg",
+            "cairosvg<2" if sys.version_info.major < 3 else "cairosvg",
             "pillow"
         ],
     },

--- a/test/test_render.py
+++ b/test/test_render.py
@@ -45,7 +45,7 @@ def test_upstream(tmpdir,wavedromdir,file):
     f_out = "{}/{}.svg".format(tmpdir, base)
     f_out_py = "{}/{}_py.svg".format(tmpdir, base)
 
-    subprocess.check_call("{}/bin/cli.js -i {} > {}".format(wavedromdir, file, f_out), shell=True)
+    subprocess.check_call("node {}/bin/cli.js -i {} > {}".format(wavedromdir, file, f_out), shell=True)
     wavedrom.render_file(file, f_out_py, strict_js_features=True)
 
     unknown = diff(f_out, f_out_py)

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,11 @@
 envlist = py27, py35, py36, py37
 
 [testenv]
-deps = pytest
+conda_channels = conda-forge
+conda_deps =
+    nodejs
+    git
+    pytest
 extras = test
 
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36
+envlist = py27, py35, py36, py37
 
 [testenv]
 deps = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py35, py36
+
+[testenv]
+deps = pytest
+extras = test
+
+commands =
+    pytest -v {posargs}


### PR DESCRIPTION
Sequential:  Consider this PR after PR #23.

This uses [tox-conda](https://github.com/tox-dev/tox-conda) to manage the dependencies for testing.  All it takes to perform testing in all versions of Python is:
1. Install miniconda (either 2 or 3)
2. `conda env create -n wavedrompy-test -c conda-forge tox-conda`
3. Navigate to source directory
4. `tox`