### PR TITLE
Freeze upstream version

### DIFF
--- a/test/test_render.py
+++ b/test/test_render.py
@@ -35,6 +35,7 @@ def wavedromdir(tmpdir_factory):
     else:
         wavedromdir = tmpdir_factory.mktemp("wavedrom")
         subprocess.check_call("git clone https://github.com/wavedrom/wavedrom.git {}".format(wavedromdir), shell=True)
+        subprocess.check_call("git reset --hard 1d4d25181d6660b5d069defcf04583158b51aa5c~1", cwd=str(wavedromdir), shell=True)
         subprocess.check_call("npm install", cwd=str(wavedromdir), shell=True)
         return wavedromdir
 


### PR DESCRIPTION
As identified in the comments to PR #23, a change upstream at [1d4d251](https://github.com/wavedrom/wavedrom/commit/1d4d25181d6660b5d069defcf04583158b51aa5c) causes the upstream tests to fail.  Until a fix is implemented in this project to match upstream behavior, testing will be limited to the commit before [1d4d251](https://github.com/wavedrom/wavedrom/commit/1d4d25181d6660b5d069defcf04583158b51aa5c).

To see for yourself, add -x to the tox test command (to save yourself from the huge xml diff log):
```ini
commands =
    pytest -v {posargs} -x
```
and remove that `~1` from the git hash.  It looks like it's just a quirk of how the SVG is encoding because every file fails.  Even the ones that didn't use the new background colors.  Almost like those colors were defined in some sort of style or entity definition, and that's what's throwing off your diff?