### PR TITLE
Specify supported Python versions as v3.7 and up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
-  - "2.7"
-  - "3.5"
-  - "3.6"
   - "3.7"
+  - "3.8"
+  - "3.9"
+  - "3.10"
 
 before_install:
   - sudo apt-get install -y npm

--- a/setup.py
+++ b/setup.py
@@ -100,14 +100,11 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3"
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10"
     ],
 
     # This field adds keywords for your project which will appear on the
@@ -134,6 +131,9 @@ setup(
     # For an analysis of "install_requires" vs pip"s requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
     install_requires=requires,  # Optional
+
+    # The minimum required Python version for installation
+    python_requires='>=3.7',
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). Users will be able to install these using the "extras"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, py37
+envlist = py37, py38, py39, p310
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
I tried installing this package on Python3.6 and it failed so I assume support for v3.6 and lower has been dropped.
This PR changes the `setup.py` file, `travis.yml` and `tox.ini` to specify support for Python versions 3.7 and up.