### PR TITLE
README: Removed spurious ']' from bitfield example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Finally, wavedrom can draw registers as bitfields:
       { "name": "Clear", "bits": 3 },
       { "bits": 8 }
       ]
-    ]}""")
+    }""")
     svg.saveas("demo3.svg")
 
     


### PR DESCRIPTION
A spurios second ']' closing bracket in the README's bitfield example breaks the example. This fixes the example.

Thank you for the great package!