### PR TITLE
fix: replace yaml.FullLoader with yaml.safe_load (CVE-915)

### DIFF
--- a/wavedrom/__init__.py
+++ b/wavedrom/__init__.py
@@ -17,7 +17,7 @@ import json
 
 def fixQuotes(inputString):
     # fix double quotes in the input file. opening with yaml and dumping with json fix the issues.
-    yamlCode = yaml.load(inputString, Loader=yaml.FullLoader)
+    yamlCode = yaml.safe_load(inputString)
     fixedString = json.dumps(yamlCode, indent=4)
     return fixedString
 


### PR DESCRIPTION
## Summary

Replace yaml.load(inputString, Loader=yaml.FullLoader) with yaml.safe_load(inputString) in wavedrom/__init__.py to fix CWE-915 vulnerability when processing untrusted YAML diagram input.

## Security Fix

CWE-915: Improperly Controlled Modification of Dynamically-Determined Object Attributes

- FullLoader permits YAML constructs beyond JSON-equivalent data (!!python/name, !!python/object)
- SafeLoader only allows JSON-equivalent types — no functionality lost
- Fixes vulnerability when processing untrusted YAML diagram input

## Changed

Before: yamlCode = yaml.load(inputString, Loader=yaml.FullLoader)
After:  yamlCode = yaml.safe_load(inputString)

## Testing

- Syntax validated with python3 -m py_compile
- Fix addresses issue #51